### PR TITLE
Update to upstream 0.17.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages, find_namespace_packages
 
 setup(
     name='RobotRaconteurCompanion',
-    version='0.1.11',
+    version='0.2.0',
     description='Robot Raconteur Python Companion Library',
     author='John Wason',
     author_email='wason@wasontech.com',
@@ -15,7 +15,7 @@ setup(
         '*.robdef'
     ]},
     install_requires=[
-        'RobotRaconteur',
+        'RobotRaconteur>=0.17.0',
         'numpy',
         'PyYAML',
         'setuptools',

--- a/src/RobotRaconteurCompanion/StdRobDef/__init__.py
+++ b/src/RobotRaconteurCompanion/StdRobDef/__init__.py
@@ -52,7 +52,7 @@ STANDARD_ROBDEF_TEXT={}
 def _load_standard_robdef_text():
     import importlib_resources
     for n in STANDARD_ROBDEF_NAMES:
-        robdef_text = importlib_resources.read_text(__package__, n + '.robdef')
+        robdef_text = (importlib_resources.files() / (n + '.robdef')).read_text()
         STANDARD_ROBDEF_TEXT[n] = robdef_text
 
 _load_standard_robdef_text()

--- a/src/RobotRaconteurCompanion/Util/LocalIdentifiersManager.py
+++ b/src/RobotRaconteurCompanion/Util/LocalIdentifiersManager.py
@@ -10,85 +10,17 @@ import numpy as np
 import stat
 import errno
 
-if sys.platform == 'win32':
-    import msvcrt
-else:
-    import fcntl
+class _LocalIdentifiersManagerFD(object):
+    def __init__(self,fd):
+        self.fd = fd
+    def __enter__(self):
+        pass
 
-def _get_user_data_path():
-    if sys.platform == 'win32':
-        buf = ctypes.create_unicode_buffer(1024)
-        assert ctypes.windll.shell32.SHGetFolderPathW(None,0x001c | 0x8000, None, 0, buf) == 0
-        p = Path(buf.value).joinpath("RobotRaconteur")
-        p.mkdir(parents = True, exist_ok = True)
-        return p
-    else:
-        path1 = os.environ["HOME"]
-        assert path1 is not None, "Home directory not set"
-        p = Path(path1).joinpath(".config").joinpath("RobotRaconteur")
-        p.mkdir(parents = True, exist_ok = True)
-        return p
-
-def _get_user_run_path():
-    if sys.platform == 'win32':
-        buf = ctypes.create_unicode_buffer(1024)
-        assert ctypes.windll.shell32.SHGetFolderPathW(None,0x001c | 0x8000, None, 0, buf) == 0
-        p = Path(buf.value).joinpath("RobotRaconteur").joinpath("run")
-        p.mkdir(parents = True, exist_ok = True)
-        return p
-    elif sys.platform == 'darwin':
-        u = os.getuid()
-        if u == 0:
-            path = Path("/var/run/robotraconteur/root")
-            path.mkdir(parents = True, exist_ok = True)
-            path.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
-        else:
-            path1 = os.environ["TMPDIR"]
-            assert path1 is not None, "Could not activate system for local identifier manager"
-            path = Path(path1).parent.joinpath("C")
-            assert path.is_dir(), "Could not activate system for local identifier manager"
-            path = path.joinpath("robotraconteur")
-        path.mkdir(parents = True, exist_ok = True)
-        return path
-    else:
-        u = os.getuid()
-        if u == 0:
-            path = Path("/var/run/robotraconteur/root")
-            path.mkdir(parents = True, exist_ok = True)
-            path.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
-        else:
-            path1 = os.environ["XDG_RUNTIME_DIR"]
-            assert path1 is not None, "Could not activate system for local identifier manager"
-            path = Path(path1)
-            assert path.is_dir(), "Could not activate system for local identifier manager"
-            path = path.joinpath("robotraconteur")
-        path.mkdir(parents = True, exist_ok = True)
-        return path
-
-def _get_user_identifier_path():
-    p = _get_user_data_path().joinpath("identifiers")
-    p.mkdir(parents = True, exist_ok = True)
-    return p
-
-def _open_lock_write(file_path):    
-    if sys.platform == "win32":
-        fname_buf = ctypes.create_unicode_buffer(str(file_path))
-        h = ctypes.windll.kernel32.CreateFileW(fname_buf, 0x80000000 | 0x40000000, 0x00000001, None, 4, 0x00000080, None)
-        if h == -1:
-            win_err = ctypes.windll.kernel32.GetLastError()
-            if win_err ==  32:
-                raise RR.InvalidOperationException("Identifier name in use")
-            else:
-                assert False, "Could not activate system for local identifier manager"
-        fd = msvcrt.open_osfhandle(h,os.O_APPEND | os.O_TEXT)
-        f = os.fdopen(fd, "r+",encoding="ascii")
-        return f
-    else:
-        fd1 = os.open(str(file_path),os.O_CLOEXEC | os.O_RDWR | os.O_APPEND | os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP)        
-        f = os.fdopen(fd1, "r+",encoding="ascii")
-        fcntl.lockf(f,fcntl.LOCK_EX)
-        return f
-        
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.fd is not None:
+            fd = self.fd
+            self.fd = None
+            del fd
 
 class LocalIdentifiersManager(object):
 
@@ -101,36 +33,13 @@ class LocalIdentifiersManager(object):
         assert re.match("^[a-zA-Z][a-zA-Z0-9_\\.\\-]*$",name) is not None, "Invalid identifier name"
         category2=category.lower()
 
-        p1 = _get_user_identifier_path().joinpath(category)
-        p1.mkdir(parents = True, exist_ok = True)
-        p = p1.joinpath(name)
+        node_dirs = self._node.GetNodeDirectories()
+        p = RR.GetUuidForNameAndLock(node_dirs,name,["identifiers",category2])
 
-        if sys.platform == "win32":
-            f = _open_lock_write(p)
-        else:
-            p_lock1 = _get_user_run_path().joinpath("identifiers").joinpath(category)
-            p_lock1.mkdir(parents = True, exist_ok = True)
-            p_lock = p_lock1.joinpath(name + ".pid")
-            f_run = _open_lock_write(p_lock)
-            f_run.seek(0,0)
-            f_run.truncate()
-            f_run.write(str(os.getpid()))
-
-            try:
-                f = _open_lock_write(p)
-            except OSError as x:
-                if x.errno == errno.EROFS:
-                    f = open(p,'r',encoding="ascii")
-                else:
-                    raise
-
-        f.seek(0,0)
-        f_text = f.read()
-        if len(f_text) == 0:
-            ident_uuid = uuid.uuid4()
-            f.write("{" + str(ident_uuid) + "}")
-        else:
-            ident_uuid = uuid.UUID(str(f_text))
+        f = p.fd
+        f_text = p.uuid.ToString("D")
+        
+        ident_uuid = uuid.UUID(str(f_text))
 
         ident_type = self._node.GetStructureType("com.robotraconteur.identifier.Identifier",self._client_object)
         uuid_dtype = self._node.GetNamedArrayDType("com.robotraconteur.uuid.UUID",self._client_object)
@@ -138,8 +47,6 @@ class LocalIdentifiersManager(object):
         ret.name = name
         ret.uuid = np.zeros((1,),dtype=uuid_dtype)
         ret.uuid["uuid_bytes"] = np.frombuffer(ident_uuid.bytes,dtype=np.uint8)
-        if sys.platform == "win32":
-            return ret,f
-        else:
-            f.close()
-            return ret,f_run
+        
+        return ret, _LocalIdentifiersManagerFD(f)
+       

--- a/src/RobotRaconteurCompanion/Util/RobDef.py
+++ b/src/RobotRaconteurCompanion/Util/RobDef.py
@@ -13,7 +13,7 @@ def get_service_type_from_resource(package, resource):
     ext = ""
     if importlib.resources.is_resource(package, resource + ".robdef"):
         ext = ".robdef"    
-    robdef_text = importlib.resources.read_text(package,resource + ext)
+    robdef_text = (importlib.resources.files(package) / (resource + ext)).read_text()
     return robdef_text
 
 def get_service_types_from_resources(package, resources):
@@ -22,6 +22,6 @@ def get_service_types_from_resources(package, resources):
         ext = ""
         if importlib.resources.is_resource(package, resource + ".robdef"):
             ext = ".robdef"
-        robdef_text = importlib.resources.read_text(package,resource + ext)
+        robdef_text = (importlib.resources.read_text(package) / (resource + ext)).read_text()
         robdefs_text.append(robdef_text)
     return robdefs_text

--- a/test/infoparser/test_infoparser.py
+++ b/test/infoparser/test_infoparser.py
@@ -9,7 +9,7 @@ def test_infoparser():
     node.Init()
     try:
         RRC.RegisterStdRobDefServiceTypes(node)
-        info_text = importlib_resources.read_text(__package__, 'sawyer_robot_default_config.yml')
+        info_text = (importlib_resources.files(__package__) /('sawyer_robot_default_config.yml')).read_text()
         parser = InfoParser(node)
         robot_info = parser.ParseInfoString(info_text,"com.robotraconteur.robotics.robot.RobotInfo")
         rr_robot_info = PackMessageElement(robot_info,f"com.robotraconteur.robotics.robot.RobotInfo",node=node)

--- a/test/util/test_infofileloader.py
+++ b/test/util/test_infofileloader.py
@@ -9,7 +9,7 @@ def test_infoparser():
     node.Init()
     try:
         RRC.RegisterStdRobDefServiceTypes(node)
-        info_text = importlib_resources.read_text(test_infoparser_m, 'sawyer_robot_default_config.yml')
+        info_text = (importlib_resources.files(test_infoparser_m) / ('sawyer_robot_default_config.yml')).read_text()
         parser = InfoFileLoader(node)
         robot_info, fd = parser.LoadInfoFileFromString(info_text,"com.robotraconteur.robotics.robot.RobotInfo",category="test")
         with fd:            

--- a/test/util/test_local_identifier_manager.py
+++ b/test/util/test_local_identifier_manager.py
@@ -2,15 +2,6 @@ import RobotRaconteurCompanion.Util.LocalIdentifiersManager as id_manager
 import RobotRaconteur as RR
 import RobotRaconteurCompanion as RRC
 
-def test_get_paths():
-    path = id_manager._get_user_identifier_path()
-    path2 = id_manager._get_user_run_path()
-    path3 = id_manager._get_user_identifier_path()
-
-    print(path)
-    print(path2)
-    print(path3)
-
 def test_identifier_lock():
     node = RR.RobotRaconteurNode()
     node.Init()


### PR DESCRIPTION
Update to upstream Robot Raconteur library version 0.17.0

* Use new "node directories" to manage temporary node ids
* Use `importlib_resources.path` instead of deprecated functions
* Bump version to 0.2.0